### PR TITLE
Bump nodejs version to 18

### DIFF
--- a/images/n8n-debian/Dockerfile
+++ b/images/n8n-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs14
+FROM nikolaik/python-nodejs:python3.10-nodejs18
 
 # changing user `pn` to `node`
 RUN usermod --login node --move-home --home /home/node pn

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs14-alpine
+FROM nikolaik/python-nodejs:python3.10-nodejs18-alpine
 
 # changing user `pn` to `node`
 RUN deluser pn && rm -r /home/pn # delete: user + group


### PR DESCRIPTION
Newer versions of n8n require Node.js above 16 to getting work.
