### PR TITLE
Patched github workflow for docker build.

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -38,7 +38,7 @@ jobs:
           context: ./images/n8n
           build-args: |
             N8N_VERSION=${{steps.vars.outputs.tag}}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/n8n-python:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
The base image used to build the default n8n-python image is nikolaik/python-nodejs:python3.10-nodejs18-alpine which only supports linux/amd64. Check here: [nikolaik/python-nodejs:python3.10-nodejs18-alpine](https://hub.docker.com/layers/nikolaik/python-nodejs/python3.10-nodejs18-alpine/images/sha256-817982f55971c6e96fc4d7d608c397bf5ff66b71df2046d656ba1145e8dd08c7?context=explore)

