### PR TITLE
N8n not recognizing the "n8n-nodes-python" package.

### DIFF
--- a/images/n8n-debian/Dockerfile
+++ b/images/n8n-debian/Dockerfile
@@ -24,7 +24,7 @@ USER root
 RUN npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION}
 
 # Install n8n-nodes-python module
-RUN cd /usr/lib/node_modules/n8n && npm install n8n-nodes-python
+RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 ENV NODE_ICU_DATA /usr/lib/node_modules/full-icu
 

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update add --virtual build-dependencies build-base ca-certificates && 
 	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root;
 
 # Install n8n-nodes-python module
-RUN cd /usr/local/lib/node_modules/n8n && npm install n8n-nodes-python
+RUN cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 # Install fonts
 RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update add --virtual build-dependencies build-base ca-certificates && 
 	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root;
 
 # Install n8n-nodes-python module
-RUN cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
+RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 # Install fonts
 RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \


### PR DESCRIPTION
## Problem Description:
After deploying using the n8n:1.22.0 image, PythonFunction cannot be found.

## Problem Cause:
Incorrect path for n8n-nodes-python install.