### PR TITLE
N8n not recognizing the "n8n-nodes-python" package.

### DIFF
--- a/images/n8n-debian/Dockerfile
+++ b/images/n8n-debian/Dockerfile
@@ -24,7 +24,7 @@ USER root
 RUN npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION}
 
 # Install n8n-nodes-python module
-RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
+RUN npm install n8n-nodes-python --prefix /home/node/custom/.n8n/nodes/ && mkdir /home/node/.n8n
 
 ENV NODE_ICU_DATA /usr/lib/node_modules/full-icu
 

--- a/images/n8n-debian/Dockerfile
+++ b/images/n8n-debian/Dockerfile
@@ -24,7 +24,7 @@ USER root
 RUN npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION}
 
 # Install n8n-nodes-python module
-RUN cd /usr/lib/node_modules/n8n && npm install n8n-nodes-python
+RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 ENV NODE_ICU_DATA /usr/lib/node_modules/full-icu
 

--- a/images/n8n-debian/docker-entrypoint.sh
+++ b/images/n8n-debian/docker-entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-if [ -d /root/.n8n ] ; then
-  chmod o+rx /root
-  chown -R node /root/.n8n
-  ln -s /root/.n8n /home/node/
+if [ -d /home/node/custom/.n8n/nodes/ ] ; then
+  chmod o+rx /home/node/custom
+  chown -R node /home/node/custom/.n8n/
+  ln -s /home/node/custom/.n8n/nodes/ /home/node/.n8n/
 fi
+
+chown -R node /home/node
 
 if [ "$#" -gt 0 ]; then
   # Got started with arguments

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update add --virtual build-dependencies build-base ca-certificates && 
 	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root;
 
 # Install n8n-nodes-python module
-RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
+RUN npm install n8n-nodes-python --prefix /home/node/custom/.n8n/nodes/ && mkdir /home/node/.n8n 
 
 # Install fonts
 RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update add --virtual build-dependencies build-base ca-certificates && 
 	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root;
 
 # Install n8n-nodes-python module
-RUN cd /usr/local/lib/node_modules/n8n && npm install n8n-nodes-python
+RUN cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 # Install fonts
 RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \

--- a/images/n8n/Dockerfile
+++ b/images/n8n/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update add --virtual build-dependencies build-base ca-certificates && 
 	&& rm -rf /root /tmp/* /var/cache/apk/* && mkdir /root;
 
 # Install n8n-nodes-python module
-RUN cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
+RUN mkdir -p /home/node/.n8n/nodes/ && cd /home/node/.n8n/nodes/ && npm install n8n-nodes-python
 
 # Install fonts
 RUN apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \

--- a/images/n8n/docker-entrypoint.sh
+++ b/images/n8n/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ -d /root/.n8n ] ; then
-  chmod o+rx /root
-  chown -R node /root/.n8n
-  ln -s /root/.n8n /home/node/
+if [ -d /home/node/custom/.n8n/nodes/ ] ; then
+  chmod o+rx /home/node/custom
+  chown -R node /home/node/custom/.n8n/
+  ln -s /home/node/custom/.n8n/nodes/ /home/node/.n8n/
 fi
 
 chown -R node /home/node


### PR DESCRIPTION

# Problem Description:

After deploying using the n8n:1.22.0 image, PythonFunction cannot be found.

# Problem Cause:

Incorrect path for n8n-nodes-python install.
