### PR TITLE
Fix CI/CD code

### DIFF
--- a/.github/workflows/auto-check-new-releases.yml
+++ b/.github/workflows/auto-check-new-releases.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Fetch release version
         id: fetch-version
         run: |
-          curl -sL https://raw.githubusercontent.com/n8n-io/n8n/master/package.json | jq -r ".version" > release-versions/n8n-latest.txt
+          curl -s https://api.github.com/repos/n8n-io/n8n/releases/latest | jq -r '.tag_name' | cut -d'@' -f2 > release-versions/n8n-latest.txt
           echo ::set-output name=version::$(cat release-versions/n8n-latest.txt)
 
       #      - name: Check for modified files


### PR DESCRIPTION
roblem Description:
The CI recognized n8n@1.38.0 as the latest version, but it was actually a pre-release version.

Problem Cause:
The version specified in the main/package.json does not match the version released on npm.