### PR TITLE
Introduce N8N functionality to support custom certificates

### DIFF
--- a/images/n8n/docker-entrypoint.sh
+++ b/images/n8n/docker-entrypoint.sh
@@ -8,6 +8,14 @@ fi
 
 chown -R node /home/node
 
+# Check if custom certificates are provided 
+if [ -d /opt/custom-certificates ]; then
+  echo "Trusting custom certificates from /opt/custom-certificates."
+  export NODE_OPTIONS=--use-openssl-ca $NODE_OPTIONS
+  export SSL_CERT_DIR=/opt/custom-certificates
+  c_rehash /opt/custom-certificates
+fi
+
 if [ "$#" -gt 0 ]; then
   # Got started with arguments
   exec su-exec node "$@"


### PR DESCRIPTION
Documentation at https://docs.n8n.io/hosting/configuration/configuration-examples/custom-certificate-authority indicates that when the directory `/opt/custom-certificates` exists, those certs should be added to the trusted CAs. 

This PR introduces the same logic as in https://github.com/n8n-io/n8n/blob/master/docker/images/n8n/docker-entrypoint.sh , which tests for the existence of this directory and attempts to install the supported CA certs.

